### PR TITLE
add RuntimeData field to VirtualMachine

### DIFF
--- a/wasm/vm.go
+++ b/wasm/vm.go
@@ -20,6 +20,7 @@ type (
 		Globals       []uint64
 
 		OperandStack *VirtualMachineOperandStack
+		RuntimeData  interface{}
 	}
 
 	NativeFunctionContext struct {

--- a/wasm/vm.go
+++ b/wasm/vm.go
@@ -20,7 +20,8 @@ type (
 		Globals       []uint64
 
 		OperandStack *VirtualMachineOperandStack
-		RuntimeData  interface{}
+		// used to store runtime data per VirtualMachine
+		RuntimeData interface{}
 	}
 
 	NativeFunctionContext struct {


### PR DESCRIPTION
This `RuntimeData` can be used to persist runtime status  for `wasm`.