### PR TITLE
Fix table index bug

### DIFF
--- a/wasm/module.go
+++ b/wasm/module.go
@@ -121,40 +121,48 @@ func (m *Module) buildIndexSpaces(externModules map[string]*Module) error {
 
 func (m *Module) resolveImports(externModules map[string]*Module) error {
 	for _, is := range m.SecImports {
-		em, ok := externModules[is.Module]
-		if !ok {
-			return fmt.Errorf("failed to resolve import of module name %s", is.Module)
-		}
-
-		es, ok := em.SecExports[is.Name]
-		if !ok {
-			return fmt.Errorf("%s not exported in module %s", is.Name, is.Module)
-		}
-
-		if is.Desc.Kind != es.Desc.Kind {
-			return fmt.Errorf("type mismatch on export: got %#x but want %#x", es.Desc.Kind, is.Desc.Kind)
-		}
-		switch is.Desc.Kind {
-		case 0x00: // function
-			if err := m.applyFunctionImport(is, em, es); err != nil {
-				return fmt.Errorf("applyFunctionImport failed: %w", err)
-			}
-		case 0x01: // table
-			if err := m.applyTableImport(em, es); err != nil {
-				return fmt.Errorf("applyTableImport failed: %w", err)
-			}
-		case 0x02: // mem
-			if err := m.applyMemoryImport(em, es); err != nil {
-				return fmt.Errorf("applyMemoryImport: %w", err)
-			}
-		case 0x03: // global
-			if err := m.applyGlobalImport(em, es); err != nil {
-				return fmt.Errorf("applyGlobalImport: %w", err)
-			}
-		default:
-			return fmt.Errorf("invalid kind of import: %#x", is.Desc.Kind)
+		if err := m.resolveImport(is, externModules); err != nil {
+			return fmt.Errorf("%s: %w", is.Name, err)
 		}
 	}
+	return nil
+}
+
+func (m *Module) resolveImport(is *ImportSegment, externModules map[string]*Module) error {
+	em, ok := externModules[is.Module]
+	if !ok {
+		return fmt.Errorf("failed to resolve import of module name %s", is.Module)
+	}
+
+	es, ok := em.SecExports[is.Name]
+	if !ok {
+		return fmt.Errorf("not exported in module %s", is.Module)
+	}
+
+	if is.Desc.Kind != es.Desc.Kind {
+		return fmt.Errorf("type mismatch on export: got %#x but want %#x", es.Desc.Kind, is.Desc.Kind)
+	}
+	switch is.Desc.Kind {
+	case 0x00: // function
+		if err := m.applyFunctionImport(is, em, es); err != nil {
+			return fmt.Errorf("applyFunctionImport failed: %w", err)
+		}
+	case 0x01: // table
+		if err := m.applyTableImport(em, es); err != nil {
+			return fmt.Errorf("applyTableImport failed: %w", err)
+		}
+	case 0x02: // mem
+		if err := m.applyMemoryImport(em, es); err != nil {
+			return fmt.Errorf("applyMemoryImport: %w", err)
+		}
+	case 0x03: // global
+		if err := m.applyGlobalImport(em, es); err != nil {
+			return fmt.Errorf("applyGlobalImport: %w", err)
+		}
+	default:
+		return fmt.Errorf("invalid kind of import: %#x", is.Desc.Kind)
+	}
+
 	return nil
 }
 

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -326,13 +326,13 @@ func (m *Module) buildTableIndexSpace() error {
 		if size > len(table) {
 			next := make([]*uint32, size)
 			copy(next, table)
-			for i, b := range elem.Init {
-				next[i+offset] = &b
+			for i := range elem.Init {
+				next[i+offset] = &elem.Init[i]
 			}
 			m.IndexSpace.Table[elem.TableIndex] = next
 		} else {
-			for i, b := range elem.Init {
-				table[i+offset] = &b
+			for i := range elem.Init {
+				table[i+offset] = &elem.Init[i]
 			}
 		}
 	}

--- a/wasm/module_test.go
+++ b/wasm/module_test.go
@@ -506,6 +506,23 @@ func TestModule_buildTableIndexSpace(t *testing.T) {
 				},
 				exp: [][]*uint32{{nil, uint32Ptr(0x01), nil}},
 			},
+			{
+				m: &Module{
+					SecElements: []*ElementSegment{{
+						TableIndex: 0,
+						OffsetExpr: &ConstantExpression{
+							optCode: OptCodeI32Const,
+							data:    []byte{0x0},
+						},
+						Init: []uint32{0x1, 0x2},
+					}},
+					SecTables: []*TableType{{Limit: &LimitsType{}}},
+					IndexSpace: &ModuleIndexSpace{
+						Table: [][]*uint32{{}},
+					},
+				},
+				exp: [][]*uint32{{uint32Ptr(0x01), uint32Ptr(0x02)}},
+			},
 		} {
 			require.NoError(t, c.m.buildTableIndexSpace())
 			require.Len(t, c.m.IndexSpace.Table, len(c.exp))


### PR DESCRIPTION
Hi @mathetake! First of all, nice work with this project!

I tried running a rust-compiled hello world program with the `wasm32-wasi` target, started adding the required methods into the `wasi` package, and was pretty excited to get it working, but then kept getting a `function signature mismatch` panic from the `callIndirect` function in `vm_call.go`. It took me quite a while to debug, and I got to understand the wasm binary format way better because of it, but finally found the culprit:

There's a classic bug in the code that populates the table index space. This loop:
```go
for i, b := range elem.Init {
	table[i+offset] = &b
}
```
Takes the pointer of the temporary variable, which is reused on every iteration. The fix is just to use `table[i+offset] = &elem.Init[i]`.

Hope you see this pull request, and merge it! I want to contribute some more code to the `wasi` package afterwards.