### PR TITLE
Add Compile method on Engine interface.

### DIFF
--- a/wasm/engine.go
+++ b/wasm/engine.go
@@ -4,4 +4,5 @@ const PageSize uint64 = 65536
 
 type Engine interface {
 	Call(f *FunctionInstance, args ...uint64) (returns []uint64, err error)
+	Compile(f *FunctionInstance) error
 }


### PR DESCRIPTION
This completes the migration for moving all the interpreter specific logics under `Engine` interface.