### PR TITLE
Renames to tetratelabs/wazero

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-2021 Takeshi Yoneda
+   Copyright 2020-2021 Tetrate
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ format:
 	    awk '/^import \($$/,/^\)$$/{if($$0=="")next}{print}' $$f > /tmp/fmt; \
 	    mv /tmp/fmt $$f; \
 	done
-	@go run $(goimports) -w -local github.com/mathetake/gasm `find . -name '*.go'`
+	@go run $(goimports) -w -local github.com/tetratelabs/wazero `find . -name '*.go'`
 
 .PHONY: check
 check:

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
-Gasm
-Copyright 2020-2021 Takeshi Yoneda
+wazero
+Copyright 2020-2021 Tetrate

--- a/README.md
+++ b/README.md
@@ -1,27 +1,14 @@
-# Gasm
+# wazero
 
-A minimal WebAssembly runtime purely written in Go. The runtime passes all the [Wasm Spec test suites](https://github.com/WebAssembly/spec/tree/wg-1.0/test/core) and is fully compatible with the WebAssembly v1.0 Specification.
-
-This library can be embedded in your Go program without any dependency like cgo, and enables Gophers to write Wasm host environments easily.
-
-## Background
-
-If you want to provide Wasm host environments in your Go programs, currently there's no other choice than using CGO and leveraging the state-of-the-art runtimes written in C++/Rust (e.g. V8, Wasmtime, Wasmer, WAVM, etc.), and there's no pure Go Wasm runtime out there. (There's only one exception named [wagon](https://github.com/go-interpreter/wagon), but it was archived with the mention to this project.)
-
-First of all, why do you want to write host environments in Go? You might want to have plugin systems in your Go project and want these plugin systems to be safe/fast/flexible, and enable users to
-write plugins in their favorite lanugages. That's where Wasm comes into play. You write your own Wasm host environments and embed Wasm runtime in your projects, and now users are able to write plugins in their own favorite lanugages (AssembyScript, C, C++, Rust, Zig, etc.). As an specific example, you maybe write proxy severs in Go and want to allow users to extend the proxy via [Proxy-Wasm ABI](https://github.com/proxy-wasm/spec). Maybe you are writing server-side rendering applications via Wasm, or [OpenPolicyAgent](https://www.openpolicyagent.org/docs/latest/wasm/) is using Wasm for plugin system.
-
-However, experienced Golang developers often avoid using CGO because [_CGO is not Go_](https://dave.cheney.net/2016/01/18/cgo-is-not-go)[ -- _Rob_ _Pike_](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=757s), and it introduces another complexity into your projects. But unfortunately, as I mentioned there's no pure Go Wasm runtime out there, so you have to resort to CGO.
-
-Currently any performance optimization hasn't been done to this runtime yet, and the runtime is just a simple interpreter of Wasm binary. That means in terms of performance, the runtime here is infereior to any aforementioned runtimes (e.g. Wasmtime) for now.
-
-However _theoretically speaking_, this project have the potential to compete with these state-of-the-art JIT-style runtimes. The rationale for that is it is well-know that [CGO is slow](https://github.com/golang/go/issues/19574). More specifically, if you make large amount of CGO calls which cross the boundary between Go and C (stack) space, then the usage of CGO could be a bottleneck.
-
-Luckily with unsafe pointer casts, we can do JIT compilation purely in Go (e.g. https://github.com/bspaans/jit-compiler), so if we develop JIT Wasm compiler in Go without using CGO, this runtime could be the fastest one for some usecases where we have to make large amount of CGO calls (e.g. Proxy-Wasm host environment, or request-based plugin systems).
-
-So as a long-term goal for this project, we are planning to add lowering of Wasm binary into more efficient and powerful format, and a JIT compilation engine purely written in Go.
+wazero lets you run WebAssembly modules with zero platform dependencies. Since wazero doesn’t rely on CGO, you keep
+portability features like cross compilation. Import wazero and extend your Go application with code written in any
+language!
 
 ## Example
+Here's an example of using wazero to invoke a Fibonacci function included in a Wasm binary.
+
+While our [source for this](examples/wasm/fibonacci.go) is [TinyGo](https://tinygo.org/), it could have been written in
+another language that targets Wasm, such as Rust.
 
 ```golang
 func Test_fibonacci(t *testing.T) {
@@ -46,3 +33,26 @@ func Test_fibonacci(t *testing.T) {
 }
 
 ```
+
+## Status
+wazero is an early project, so APIs are subject to change until version 1.0.
+
+The wazero runtime passes all the [Wasm Spec test suites](https://github.com/WebAssembly/spec/tree/wg-1.0/test/core) and
+is fully compatible with the WebAssembly v1.0 Specification.
+
+## Background
+
+If you want to provide Wasm host environments in your Go programs, currently there's no other choice than using CGO and leveraging the state-of-the-art runtimes written in C++/Rust (e.g. V8, Wasmtime, Wasmer, WAVM, etc.), and there's no pure Go Wasm runtime out there. (There's only one exception named [wagon](https://github.com/go-interpreter/wagon), but it was archived with the mention to this project.)
+
+First of all, why do you want to write host environments in Go? You might want to have plugin systems in your Go project and want these plugin systems to be safe/fast/flexible, and enable users to
+write plugins in their favorite lanugages. That's where Wasm comes into play. You write your own Wasm host environments and embed Wasm runtime in your projects, and now users are able to write plugins in their own favorite lanugages (AssembyScript, C, C++, Rust, Zig, etc.). As an specific example, you maybe write proxy severs in Go and want to allow users to extend the proxy via [Proxy-Wasm ABI](https://github.com/proxy-wasm/spec). Maybe you are writing server-side rendering applications via Wasm, or [OpenPolicyAgent](https://www.openpolicyagent.org/docs/latest/wasm/) is using Wasm for plugin system.
+
+However, experienced Golang developers often avoid using CGO because [_CGO is not Go_](https://dave.cheney.net/2016/01/18/cgo-is-not-go)[ -- _Rob_ _Pike_](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=757s), and it introduces another complexity into your projects. But unfortunately, as I mentioned there's no pure Go Wasm runtime out there, so you have to resort to CGO.
+
+Currently any performance optimization hasn't been done to this runtime yet, and the runtime is just a simple interpreter of Wasm binary. That means in terms of performance, the runtime here is infereior to any aforementioned runtimes (e.g. Wasmtime) for now.
+
+However _theoretically speaking_, this project have the potential to compete with these state-of-the-art JIT-style runtimes. The rationale for that is it is well-know that [CGO is slow](https://github.com/golang/go/issues/19574). More specifically, if you make large amount of CGO calls which cross the boundary between Go and C (stack) space, then the usage of CGO could be a bottleneck.
+
+Luckily with unsafe pointer casts, we can do JIT compilation purely in Go (e.g. https://github.com/bspaans/jit-compiler), so if we develop JIT Wasm compiler in Go without using CGO, this runtime could be the fastest one for some usecases where we have to make large amount of CGO calls (e.g. Proxy-Wasm host environment, or request-based plugin systems).
+
+So as a long-term goal for this project, we are planning to add lowering of Wasm binary into more efficient and powerful format, and a JIT compilation engine purely written in Go.

--- a/examples/fibonacci_test.go
+++ b/examples/fibonacci_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/mathetake/gasm/wasi"
-	"github.com/mathetake/gasm/wasm"
-	"github.com/mathetake/gasm/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasi"
+	"github.com/tetratelabs/wazero/wasm"
+	"github.com/tetratelabs/wazero/wasm/naivevm"
 )
 
 func Test_fibonacci(t *testing.T) {

--- a/examples/file_system_test.go
+++ b/examples/file_system_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/mathetake/gasm/wasi"
-	"github.com/mathetake/gasm/wasm"
-	"github.com/mathetake/gasm/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasi"
+	"github.com/tetratelabs/wazero/wasm"
+	"github.com/tetratelabs/wazero/wasm/naivevm"
 )
 
 func writeFile(fs wasi.FS, path string, data []byte) error {

--- a/examples/host_func_test.go
+++ b/examples/host_func_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/mathetake/gasm/wasi"
-	"github.com/mathetake/gasm/wasm"
-	"github.com/mathetake/gasm/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasi"
+	"github.com/tetratelabs/wazero/wasm"
+	"github.com/tetratelabs/wazero/wasm/naivevm"
 )
 
 func Test_hostFunc(t *testing.T) {

--- a/examples/stdio_test.go
+++ b/examples/stdio_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/mathetake/gasm/wasi"
-	"github.com/mathetake/gasm/wasm"
-	"github.com/mathetake/gasm/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasi"
+	"github.com/tetratelabs/wazero/wasm"
+	"github.com/tetratelabs/wazero/wasm/naivevm"
 )
 
 func Test_stdio(t *testing.T) {

--- a/examples/trap_test.go
+++ b/examples/trap_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/mathetake/gasm/wasi"
-	"github.com/mathetake/gasm/wasm"
-	"github.com/mathetake/gasm/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasi"
+	"github.com/tetratelabs/wazero/wasm"
+	"github.com/tetratelabs/wazero/wasm/naivevm"
 )
 
 func Test_trap(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mathetake/gasm
+module github.com/tetratelabs/wazero
 
 go 1.17
 
@@ -9,5 +9,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
-
-replace github.com/mathetake/gasm => ./

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/mathetake/gasm/wasm"
+	"github.com/tetratelabs/wazero/wasm"
 )
 
 const (

--- a/wasm/const_expr.go
+++ b/wasm/const_expr.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"math"
 
-	"github.com/mathetake/gasm/wasm/leb128"
+	"github.com/tetratelabs/wazero/wasm/leb128"
 )
 
 type ConstantExpression struct {

--- a/wasm/naivevm/vm.go
+++ b/wasm/naivevm/vm.go
@@ -8,9 +8,9 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/mathetake/gasm/wasm"
-	"github.com/mathetake/gasm/wasm/buildoptions"
-	"github.com/mathetake/gasm/wasm/leb128"
+	"github.com/tetratelabs/wazero/wasm"
+	"github.com/tetratelabs/wazero/wasm/buildoptions"
+	"github.com/tetratelabs/wazero/wasm/leb128"
 )
 
 type (

--- a/wasm/naivevm/vm_call.go
+++ b/wasm/naivevm/vm_call.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/mathetake/gasm/wasm"
-	"github.com/mathetake/gasm/wasm/buildoptions"
+	"github.com/tetratelabs/wazero/wasm"
+	"github.com/tetratelabs/wazero/wasm/buildoptions"
 )
 
 func call(vm *naiveVirtualMachine) {

--- a/wasm/naivevm/vm_control.go
+++ b/wasm/naivevm/vm_control.go
@@ -3,7 +3,7 @@ package naivevm
 import (
 	"bytes"
 
-	"github.com/mathetake/gasm/wasm/leb128"
+	"github.com/tetratelabs/wazero/wasm/leb128"
 )
 
 func block(vm *naiveVirtualMachine) {

--- a/wasm/naivevm/vm_memory.go
+++ b/wasm/naivevm/vm_memory.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"math"
 
-	"github.com/mathetake/gasm/wasm"
+	"github.com/tetratelabs/wazero/wasm"
 )
 
 func memoryBase(vm *naiveVirtualMachine) uint64 {

--- a/wasm/naivevm/vm_stack.go
+++ b/wasm/naivevm/vm_stack.go
@@ -1,8 +1,8 @@
 package naivevm
 
 import (
-	"github.com/mathetake/gasm/wasm"
-	"github.com/mathetake/gasm/wasm/buildoptions"
+	"github.com/tetratelabs/wazero/wasm"
+	"github.com/tetratelabs/wazero/wasm/buildoptions"
 )
 
 const (

--- a/wasm/section.go
+++ b/wasm/section.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"unicode/utf8"
 
-	"github.com/mathetake/gasm/wasm/leb128"
+	"github.com/tetratelabs/wazero/wasm/leb128"
 )
 
 type SectionID = byte

--- a/wasm/segment.go
+++ b/wasm/segment.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"math"
 
-	"github.com/mathetake/gasm/wasm/leb128"
+	"github.com/tetratelabs/wazero/wasm/leb128"
 )
 
 type ImportKind = byte

--- a/wasm/spectests/spec_test.go
+++ b/wasm/spectests/spec_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mathetake/gasm/wasm"
-	"github.com/mathetake/gasm/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasm"
+	"github.com/tetratelabs/wazero/wasm/naivevm"
 )
 
 type (

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/mathetake/gasm/wasm/leb128"
+	"github.com/tetratelabs/wazero/wasm/leb128"
 )
 
 type (

--- a/wasm/type.go
+++ b/wasm/type.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/mathetake/gasm/wasm/leb128"
+	"github.com/tetratelabs/wazero/wasm/leb128"
 )
 
 type FunctionType struct {

--- a/wasm/value.go
+++ b/wasm/value.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"unicode/utf8"
 
-	"github.com/mathetake/gasm/wasm/leb128"
+	"github.com/tetratelabs/wazero/wasm/leb128"
 )
 
 type ValueType = byte


### PR DESCRIPTION
This renames the project to wazero, which emphasizes that this runtime
has no platform depedencies (notably CGO). To avoid having users change
their imports twice, this also changes the org to "tetratelabs" ahead of
transfer.

Exciting times ahead, wazeros!